### PR TITLE
JCR-4260 analyze-classes mojo can fail

### DIFF
--- a/.ratignore
+++ b/.ratignore
@@ -4,3 +4,5 @@ src/test/resources/test-projects/**/*.xml
 src/test/resources/test-projects/**/.vlt
 src/test/resources/test-projects/**/.vltignore
 src/test/resources/test-projects/**/.dummy
+src/test/resources/test-projects/**/*.lst
+src/test/resources/test-projects/**/*.MF

--- a/src/test/java/org/apache/jackrabbit/filevault/maven/packaging/it/AnalyzeClassesMultiModuleIT.java
+++ b/src/test/java/org/apache/jackrabbit/filevault/maven/packaging/it/AnalyzeClassesMultiModuleIT.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.jackrabbit.filevault.maven.packaging.it;
+
+import org.junit.Test;
+
+public class AnalyzeClassesMultiModuleIT {
+
+    /**
+     * Tests that the analyze classes module succeeds when run on
+     * inter-module dependencies in a multi-module setup.
+     */
+    @Test
+    public void multi_module_build_succeeds() throws Exception {
+        new ProjectBuilder()
+                .setTestProjectDir("/analyze-classes-multimodule")
+                .setTestGoals("clean", "test")
+                .setVerifyPackageContents(false)
+                .build();
+    }
+}

--- a/src/test/java/org/apache/jackrabbit/filevault/maven/packaging/it/ProjectBuilder.java
+++ b/src/test/java/org/apache/jackrabbit/filevault/maven/packaging/it/ProjectBuilder.java
@@ -98,6 +98,8 @@ public class ProjectBuilder {
 
     private boolean buildExpectedToFail;
 
+    private boolean verifyPackageContents = true;
+
     public ProjectBuilder() {
         testProjectsRoot = new File(TEST_PROJECTS_ROOT);
         testProperties = new Properties();
@@ -179,6 +181,11 @@ public class ProjectBuilder {
         return this;
     }
 
+    public ProjectBuilder setVerifyPackageContents(boolean verifyPackageContents) {
+        this.verifyPackageContents = verifyPackageContents;
+        return this;
+    }
+
     public ProjectBuilder setProperty(String name, String value) {
         testProperties.put(name, value);
         return this;
@@ -200,6 +207,10 @@ public class ProjectBuilder {
             throw e;
         } finally {
             verifier.resetStreams();
+        }
+
+        if (!verifyPackageContents) {
+            return this;
         }
 
         assertTrue("Project generates package file", testPackageFile.exists());
@@ -266,7 +277,7 @@ public class ProjectBuilder {
         }
         Collections.sort(entries);
         result = StringUtils.join(entries.iterator(), "\n");
-        assertEquals("Manifest", expected, result);
+        assertEquals("Manifest", normalizeWhitespace(expected), normalizeWhitespace(result));
         return this;
     }
 
@@ -294,7 +305,7 @@ public class ProjectBuilder {
             assertNotNull("package has a filter.xml", entry);
             String result = IOUtil.toString(zip.getInputStream(entry), "utf-8");
             String expected = FileUtils.fileRead(expectedFilterFile);
-            assertEquals("filter.xml is correct", expected, result);
+            assertEquals("filter.xml is correct", normalizeWhitespace(expected), normalizeWhitespace(result));
         }
         return this;
     }
@@ -311,5 +322,12 @@ public class ProjectBuilder {
             buf.append(line).append("\n");
         }
         return buf.toString();
+    }
+
+    /**
+     * Eliminates differences in line separators when executing tests on different platform (*nix / windows)
+     */
+    private String normalizeWhitespace(String s) {
+        return s.replaceAll("[\r\n]+", "\n");
     }
 }

--- a/src/test/resources/test-projects/analyze-classes-multimodule/a/pom.xml
+++ b/src/test/resources/test-projects/analyze-classes-multimodule/a/pom.xml
@@ -1,0 +1,40 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.jackrabbit.filevault</groupId>
+        <artifactId>package-plugin-test-pkg-parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>package-plugin-test-pkg-artifact</artifactId>
+    <packaging>bundle</packaging>
+
+    <name>Packaging test bundle artifact</name>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>3.5.0</version>
+                <extensions>true</extensions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/test/resources/test-projects/analyze-classes-multimodule/a/src/main/java/some/SomeClass.java
+++ b/src/test/resources/test-projects/analyze-classes-multimodule/a/src/main/java/some/SomeClass.java
@@ -1,0 +1,19 @@
+package some;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+public class SomeClass {}

--- a/src/test/resources/test-projects/analyze-classes-multimodule/b/pom.xml
+++ b/src/test/resources/test-projects/analyze-classes-multimodule/b/pom.xml
@@ -1,0 +1,60 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.jackrabbit.filevault</groupId>
+        <artifactId>package-plugin-test-pkg-parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>package-plugin-test-pkg</artifactId>
+    <packaging>content-package</packaging>
+    <name>Packaging test</name>
+
+    <build>
+        <plugins>
+            <!-- content package plugin -->
+            <plugin>
+                <groupId>org.apache.jackrabbit</groupId>
+                <artifactId>filevault-package-maven-plugin</artifactId>
+                <version>1.0.2-SNAPSHOT</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <failOnEmptyFilter>false</failOnEmptyFilter>
+                    <embeddeds>
+                        <embedded>
+                            <groupId>${project.groupId}</groupId>
+                            <artifactId>package-plugin-test-pkg-artifact</artifactId>
+                            <target>/libs/install</target>
+                        </embedded>
+                    </embeddeds>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>package-plugin-test-pkg-artifact</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/src/test/resources/test-projects/analyze-classes-multimodule/pom.xml
+++ b/src/test/resources/test-projects/analyze-classes-multimodule/pom.xml
@@ -1,0 +1,32 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <!-- ====================================================================== -->
+    <!-- P R O J E C T  D E S C R I P T I O N                                   -->
+    <!-- ====================================================================== -->
+    <groupId>org.apache.jackrabbit.filevault</groupId>
+    <artifactId>package-plugin-test-pkg-parent</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+    <name>Parent</name>
+    <modules>
+        <module>a</module>
+        <module>b</module>
+    </modules>
+</project>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/JCRVLT-272

jackrabbit-filevault-package-maven-plugin analyze-classes mojo can fail with "Access denied" or "...taget/classes jackrabbit-filevault-package-maven-plugin analyze-classes mojo can fail with "Access denied" or "...taget/classes is a directory""