### PR TITLE
JCRVLT-268 always use platform-independent separators to check for index

### DIFF
--- a/src/main/java/org/apache/jackrabbit/filevault/maven/packaging/VaultMojo.java
+++ b/src/main/java/org/apache/jackrabbit/filevault/maven/packaging/VaultMojo.java
@@ -27,6 +27,7 @@ import java.util.Map;
 
 import javax.annotation.Nonnull;
 
+import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.jackrabbit.filevault.maven.packaging.impl.FileValidator;
 import org.apache.jackrabbit.vault.fs.api.PathFilterSet;
@@ -257,7 +258,9 @@ public class VaultMojo extends AbstractPackageMojo {
                         InputStream in = null;
                         try {
                             in = entry.getInputStream();
-                            fileValidator.lookupIndexDefinitionInArtifact(in, entry.getName());
+                            // ArchiveEntry.name always contains platform-dependent separators, convert to forwards slashes as separator
+                            String sanitizedFileName = FilenameUtils.separatorsToUnix(entry.getName());
+                            fileValidator.lookupIndexDefinitionInArtifact(in, sanitizedFileName);
                         } finally {
                             IOUtils.closeQuietly(in);
                         }

--- a/src/main/java/org/apache/jackrabbit/filevault/maven/packaging/impl/FileValidator.java
+++ b/src/main/java/org/apache/jackrabbit/filevault/maven/packaging/impl/FileValidator.java
@@ -45,12 +45,21 @@ public class FileValidator {
     //store entries of index found in _oak_index/.content.xml
     Map<String, String> foundIndexes = new HashMap<String, String>();
 
+    /**
+     * Checks if the given input stream and file name refers to a index definition or filter file covering an oak index.
+     * @param artifactFileInputStream the input stream of the artifact to check
+     * @param artifactName the file name within the content package (using forward slashes as separators) of the artifact to check
+     * @throws IOException
+     * @throws MojoExecutionException
+     */
     public void lookupIndexDefinitionInArtifact(InputStream artifactFileInputStream, String artifactName) throws IOException, MojoExecutionException {
+        // in case this is a subpackage
         if (artifactName.endsWith("zip")) {
             ZipInputStream zipArtifactStream = new ZipInputStream(artifactFileInputStream);
             String entryName = "";
             ZipEntry entry = zipArtifactStream.getNextEntry();
             while (entry != null) {
+                // entryName must only contain forward slashes as separators
                 entryName = entry.getName();
                 if (entryName.endsWith("zip")) {
                     //recur if the entry is a zip file


### PR DESCRIPTION
definitions