### PR TITLE
JCRLT-320 upgrade maven-archiver to 3.2.0 to be compatible with Java >=

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -322,7 +322,7 @@
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-archiver</artifactId>
-            <version>3.0.0</version>
+            <version>3.2.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.codehaus.plexus</groupId>

--- a/src/test/java/org/apache/jackrabbit/filevault/maven/packaging/it/ProjectBuilder.java
+++ b/src/test/java/org/apache/jackrabbit/filevault/maven/packaging/it/ProjectBuilder.java
@@ -68,7 +68,7 @@ public class ProjectBuilder {
      */
     private static final Logger log = LoggerFactory.getLogger(ProjectBuilder.class);
 
-    private static final Set<String> IGNORED_MANIFEST_ENTRIES = new HashSet<>(Arrays.asList("Build-Jdk", "Built-By"));
+    private static final Set<String> IGNORED_MANIFEST_ENTRIES = new HashSet<>(Arrays.asList("Build-Jdk", "Built-By", "Created-By"));
 
     static final String TEST_PROJECTS_ROOT = "target/test-classes/test-projects";
 

--- a/src/test/resources/test-projects/default-test-projects/generic-unusal-jcrroot/expected-file-order.txt
+++ b/src/test/resources/test-projects/default-test-projects/generic-unusal-jcrroot/expected-file-order.txt
@@ -1,6 +1,6 @@
 META-INF/MANIFEST.MF
 META-INF/vault/
 jcr_root/apps/wcm/core/content/
-jcr_root/_rep_policy.xml
 jcr_root/etc/designs/some-thirdparty-libs/
 jcr_root/etc/cloudservices/ooyala/
+jcr_root/_rep_policy.xml

--- a/src/test/resources/test-projects/default-test-projects/generic-unusal-jcrroot/expected-manifest.txt
+++ b/src/test/resources/test-projects/default-test-projects/generic-unusal-jcrroot/expected-manifest.txt
@@ -1,9 +1,7 @@
-Archiver-Version:Plexus Archiver
 Content-Package-Description:Packaging test
 Content-Package-Id:org.apache.jackrabbit.filevault:package-plugin-test-pkg:1.0.0-SNAPSHOT
 Content-Package-Roots:/apps/some-thirdparty-libs,/apps/wcm/core/content,/etc/cloudservices/ooyala,/etc/designs/some-thirdparty-libs,/etc/packages/apache/consulting,/rep:policy
 Content-Package-Type:mixed
-Created-By:Apache Maven
 Implementation-Title:Packaging test
 Implementation-Vendor-Id:org.apache.jackrabbit.filevault
 Implementation-Version:1.0.0-SNAPSHOT

--- a/src/test/resources/test-projects/default-test-projects/generic-with-builtcd/expected-file-order.txt
+++ b/src/test/resources/test-projects/default-test-projects/generic-with-builtcd/expected-file-order.txt
@@ -1,6 +1,6 @@
 META-INF/MANIFEST.MF
 META-INF/vault/
 jcr_root/apps/wcm/core/content/
-jcr_root/_rep_policy.xml
 jcr_root/etc/designs/some-thirdparty-libs/
 jcr_root/etc/cloudservices/ooyala/
+jcr_root/_rep_policy.xml

--- a/src/test/resources/test-projects/default-test-projects/generic-with-builtcd/expected-manifest.txt
+++ b/src/test/resources/test-projects/default-test-projects/generic-with-builtcd/expected-manifest.txt
@@ -1,9 +1,7 @@
-Archiver-Version:Plexus Archiver
 Content-Package-Description:Packaging test
 Content-Package-Id:org.apache.jackrabbit.filevault:package-plugin-test-pkg:1.0.0-SNAPSHOT
 Content-Package-Roots:/apps/some-thirdparty-libs,/apps/wcm/core/content,/etc/cloudservices/ooyala,/etc/designs/some-thirdparty-libs,/etc/packages/apache/consulting,/rep:policy
 Content-Package-Type:mixed
-Created-By:Apache Maven
 Implementation-Title:Packaging test
 Implementation-Vendor-Id:org.apache.jackrabbit.filevault
 Implementation-Version:1.0.0-SNAPSHOT

--- a/src/test/resources/test-projects/default-test-projects/generic-with-metainf/expected-manifest.txt
+++ b/src/test/resources/test-projects/default-test-projects/generic-with-metainf/expected-manifest.txt
@@ -1,9 +1,7 @@
-Archiver-Version:Plexus Archiver
 Content-Package-Description:Packaging test
 Content-Package-Id:org.apache.jackrabbit.filevault:package-plugin-test-pkg:1.0.0-SNAPSHOT
 Content-Package-Roots:/apps/wcm/core/content,/rep:policy
 Content-Package-Type:mixed
-Created-By:Apache Maven
 Implementation-Title:Packaging test
 Implementation-Vendor-Id:org.apache.jackrabbit.filevault
 Implementation-Version:1.0.0-SNAPSHOT

--- a/src/test/resources/test-projects/default-test-projects/generic/expected-file-order.txt
+++ b/src/test/resources/test-projects/default-test-projects/generic/expected-file-order.txt
@@ -1,6 +1,6 @@
 META-INF/MANIFEST.MF
 META-INF/vault/
 jcr_root/apps/wcm/core/content/
-jcr_root/_rep_policy.xml
 jcr_root/etc/designs/some-thirdparty-libs/
 jcr_root/etc/cloudservices/ooyala/
+jcr_root/_rep_policy.xml

--- a/src/test/resources/test-projects/default-test-projects/generic/expected-manifest.txt
+++ b/src/test/resources/test-projects/default-test-projects/generic/expected-manifest.txt
@@ -1,9 +1,7 @@
-Archiver-Version:Plexus Archiver
 Content-Package-Description:Packaging test
 Content-Package-Id:org.apache.jackrabbit.filevault:package-plugin-test-pkg:1.0.0-SNAPSHOT
 Content-Package-Roots:/apps/some-thirdparty-libs,/apps/wcm/core/content,/etc/cloudservices/ooyala,/etc/designs/some-thirdparty-libs,/etc/packages/apache/consulting,/rep:policy
 Content-Package-Type:mixed
-Created-By:Apache Maven
 Implementation-Title:Packaging test
 Implementation-Vendor-Id:org.apache.jackrabbit.filevault
 Implementation-Version:1.0.0-SNAPSHOT

--- a/src/test/resources/test-projects/default-test-projects/htl-validation/expected-manifest.txt
+++ b/src/test/resources/test-projects/default-test-projects/htl-validation/expected-manifest.txt
@@ -1,9 +1,7 @@
-Archiver-Version:Plexus Archiver
 Content-Package-Description:Packaging test
 Content-Package-Id:org.apache.jackrabbit.filevault:package-plugin-test-pkg:1.0.0-SNAPSHOT
 Content-Package-Roots:/apps/htl/test
 Content-Package-Type:application
-Created-By:Apache Maven
 Implementation-Title:Packaging test
 Implementation-Vendor-Id:org.apache.jackrabbit.filevault
 Implementation-Version:1.0.0-SNAPSHOT

--- a/src/test/resources/test-projects/default-test-projects/resource/expected-file-order.txt
+++ b/src/test/resources/test-projects/default-test-projects/resource/expected-file-order.txt
@@ -1,6 +1,6 @@
 META-INF/MANIFEST.MF
 META-INF/vault/
 jcr_root/apps/wcm/core/content/
-jcr_root/_rep_policy.xml
 jcr_root/etc/designs/some-thirdparty-libs/
 jcr_root/etc/cloudservices/ooyala/
+jcr_root/_rep_policy.xml

--- a/src/test/resources/test-projects/default-test-projects/resource/expected-manifest.txt
+++ b/src/test/resources/test-projects/default-test-projects/resource/expected-manifest.txt
@@ -1,9 +1,7 @@
-Archiver-Version:Plexus Archiver
 Content-Package-Description:Packaging test
 Content-Package-Id:org.apache.jackrabbit.filevault:package-plugin-test-pkg:1.0.0-SNAPSHOT
 Content-Package-Roots:/apps/some-thirdparty-libs,/apps/wcm/core/content,/etc/cloudservices/ooyala,/etc/designs/some-thirdparty-libs,/etc/packages/apache/consulting,/rep:policy
 Content-Package-Type:mixed
-Created-By:Apache Maven
 Implementation-Title:Packaging test
 Implementation-Vendor-Id:org.apache.jackrabbit.filevault
 Implementation-Version:1.0.0-SNAPSHOT

--- a/src/test/resources/test-projects/manifest-generation/simple/expected-manifest.txt
+++ b/src/test/resources/test-projects/manifest-generation/simple/expected-manifest.txt
@@ -1,10 +1,8 @@
-Archiver-Version:Plexus Archiver
 Content-Package-Dependencies:apache/jackrabbit:test.content.package:0.1,apache/jackrabbit:test.content.package:1.0.4
 Content-Package-Description:This is an Example Project to verify that manifest generation is correct.
 Content-Package-Id:my/test/group:package-plugin-test-pkg:1.0.0-SNAPSHOT
 Content-Package-Roots:/apps/test,/apps/test2
 Content-Package-Type:application
-Created-By:Apache Maven
 Implementation-Title:Example Default Project
 Implementation-Vendor-Id:org.apache.jackrabbit.filevault
 Implementation-Version:1.0.0-SNAPSHOT

--- a/src/test/resources/test-projects/manifest-generation/with-bundles/expected-manifest.txt
+++ b/src/test/resources/test-projects/manifest-generation/with-bundles/expected-manifest.txt
@@ -1,9 +1,7 @@
-Archiver-Version:Plexus Archiver
 Content-Package-Description:This is an Example Project to verify that manifest generation is correct.
 Content-Package-Id:my/test/group:package-plugin-test-pkg:1.0.0-SNAPSHOT
 Content-Package-Roots:/apps/test
 Content-Package-Type:application
-Created-By:Apache Maven
 Implementation-Title:Example Default Project
 Implementation-Vendor-Id:org.apache.jackrabbit.filevault
 Implementation-Version:1.0.0-SNAPSHOT

--- a/src/test/resources/test-projects/manifest-generation/with-code/expected-manifest.txt
+++ b/src/test/resources/test-projects/manifest-generation/with-code/expected-manifest.txt
@@ -1,9 +1,7 @@
-Archiver-Version:Plexus Archiver
 Content-Package-Description:This is an Example Project to verify that manifest generation is correct.
 Content-Package-Id:my/test/group:package-plugin-test-pkg:1.0.0-SNAPSHOT
 Content-Package-Roots:/libs/apache
 Content-Package-Type:application
-Created-By:Apache Maven
 Implementation-Title:Example Default Project
 Implementation-Vendor-Id:org.apache.jackrabbit.filevault
 Implementation-Version:1.0.0-SNAPSHOT

--- a/src/test/resources/test-projects/manifest-generation/with-unused-dependencies/expected-manifest.txt
+++ b/src/test/resources/test-projects/manifest-generation/with-unused-dependencies/expected-manifest.txt
@@ -1,9 +1,7 @@
-Archiver-Version:Plexus Archiver
 Content-Package-Description:This is an Example Project to verify that manifest generation is correct.
 Content-Package-Id:my/test/group:package-plugin-test-pkg:1.0.0-SNAPSHOT
 Content-Package-Roots:/apps/test
 Content-Package-Type:application
-Created-By:Apache Maven
 Implementation-Title:Example Default Project
 Implementation-Vendor-Id:org.apache.jackrabbit.filevault
 Implementation-Version:1.0.0-SNAPSHOT

--- a/src/test/resources/test-projects/manifest-generation/with-unused-parent-dependencies/expected-manifest.txt
+++ b/src/test/resources/test-projects/manifest-generation/with-unused-parent-dependencies/expected-manifest.txt
@@ -1,9 +1,7 @@
-Archiver-Version:Plexus Archiver
 Content-Package-Description:This is an Example Project to verify that manifest generation is correct.
 Content-Package-Id:my/test/group:package-plugin-test-pkg:1.0.0-SNAPSHOT
 Content-Package-Roots:/libs/apache
 Content-Package-Type:application
-Created-By:Apache Maven
 Implementation-Title:Example Default Project
 Implementation-Vendor-Id:org.apache.jackrabbit.filevault
 Implementation-Version:1.0.0-SNAPSHOT


### PR DESCRIPTION
10

The ITs fail with this, as the format of the manifest has changed.