### PR TITLE
JCRVLT-326 only put Strings into project properties

### DIFF
--- a/src/main/java/org/apache/jackrabbit/filevault/maven/packaging/AbstractPackageMojo.java
+++ b/src/main/java/org/apache/jackrabbit/filevault/maven/packaging/AbstractPackageMojo.java
@@ -16,15 +16,12 @@
  */
 package org.apache.jackrabbit.filevault.maven.packaging;
 
-import java.beans.XMLDecoder;
-import java.beans.XMLEncoder;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
-import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.Map;
 
@@ -34,7 +31,6 @@ import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
-import org.codehaus.plexus.util.StringInputStream;
 
 import aQute.lib.base64.Base64;
 
@@ -174,6 +170,7 @@ public abstract class AbstractPackageMojo extends AbstractMojo {
      * @throws IOException 
      * @throws ClassNotFoundException 
      */
+    @SuppressWarnings("unchecked")
     Map<String, File> getEmbeddedFilesMap() throws ClassNotFoundException, IOException {
         // deserialize the map from the string representation being created via {@link AbstractMap#toString()}.
         String value = project.getProperties().getProperty(PROPERTIES_EMBEDDEDFILESMAP_KEY);

--- a/src/main/java/org/apache/jackrabbit/filevault/maven/packaging/AbstractPackageMojo.java
+++ b/src/main/java/org/apache/jackrabbit/filevault/maven/packaging/AbstractPackageMojo.java
@@ -142,17 +142,18 @@ public abstract class AbstractPackageMojo extends AbstractMojo {
     }
 
     static String serializeObjectToString(Object object) throws IOException {
-        ByteArrayOutputStream data = new ByteArrayOutputStream();
-        ObjectOutputStream out = new ObjectOutputStream(data);
-        out.writeObject(object);
-        // convert to string (every character should be mappable)
-        return Base64.encodeBase64(data.toByteArray());
+        try (ByteArrayOutputStream data = new ByteArrayOutputStream();
+             ObjectOutputStream out = new ObjectOutputStream(data)) {
+            out.writeObject(object);
+            return Base64.encodeBase64(data.toByteArray());
+        }
     }
 
     static Object deserializeObjectFromString(String value) throws IOException, ClassNotFoundException {
-        ByteArrayInputStream data = new ByteArrayInputStream(Base64.decodeBase64(value));
-        ObjectInputStream out = new ObjectInputStream(data);
-        return out.readObject();
+        try (ByteArrayInputStream data = new ByteArrayInputStream(Base64.decodeBase64(value));
+             ObjectInputStream out = new ObjectInputStream(data)) {
+            return out.readObject();
+        }
     }
 
     /**
@@ -172,7 +173,6 @@ public abstract class AbstractPackageMojo extends AbstractMojo {
      */
     @SuppressWarnings("unchecked")
     Map<String, File> getEmbeddedFilesMap() throws ClassNotFoundException, IOException {
-        // deserialize the map from the string representation being created via {@link AbstractMap#toString()}.
         String value = project.getProperties().getProperty(PROPERTIES_EMBEDDEDFILESMAP_KEY);
         if (value == null) {
             return Collections.emptyMap();

--- a/src/test/java/org/apache/jackrabbit/filevault/maven/packaging/AbstractPackageMojoTest.java
+++ b/src/test/java/org/apache/jackrabbit/filevault/maven/packaging/AbstractPackageMojoTest.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.jackrabbit.filevault.maven.packaging;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class AbstractPackageMojoTest {
+
+    @Test
+    public void testSerializeAndDeserializeObject() throws ClassNotFoundException, IOException {
+        Map<String, File> map = new HashMap<>();
+        map.put("jcr:root/some/value", new File("some/aritrary/file/üa"));
+        map.put("jcr:root/some/value2", new File("some/aritrary/file/üa"));
+        
+        String serializedObject = AbstractPackageMojo.serializeObjectToString(map);
+        Object object = AbstractPackageMojo.deserializeObjectFromString(serializedObject);
+        Assert.assertTrue(object instanceof Map<?, ?>);
+        Assert.assertEquals(map, (Map<?, ?>)object);
+    }
+}


### PR DESCRIPTION
Use java serialization to base64 string to be compliant with
the Java Properties contract.