### PR TITLE
JCRVLT-331 use DefaultArtifactRepositoryLayout for embedded filename

### DIFF
--- a/src/main/java/org/apache/jackrabbit/filevault/maven/packaging/GenerateMetadataMojo.java
+++ b/src/main/java/org/apache/jackrabbit/filevault/maven/packaging/GenerateMetadataMojo.java
@@ -47,11 +47,13 @@ import org.apache.jackrabbit.vault.fs.config.DefaultWorkspaceFilter;
 import org.apache.jackrabbit.vault.fs.io.AccessControlHandling;
 import org.apache.jackrabbit.vault.packaging.PackageId;
 import org.apache.jackrabbit.vault.packaging.PackageType;
+import org.apache.jackrabbit.vault.util.Text;
 import org.apache.maven.archiver.ManifestConfiguration;
 import org.apache.maven.archiver.MavenArchiveConfiguration;
 import org.apache.maven.archiver.MavenArchiver;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.DependencyResolutionRequiredException;
+import org.apache.maven.artifact.repository.layout.ArtifactRepositoryLayout;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -78,7 +80,7 @@ import aQute.bnd.osgi.Processor;
  */
 @Mojo(
         name = "generate-metadata",
-        defaultPhase = LifecyclePhase.PREPARE_PACKAGE,
+        defaultPhase = LifecyclePhase.PROCESS_CLASSES,
         requiresDependencyResolution = ResolutionScope.COMPILE
 )
 public class GenerateMetadataMojo extends AbstractPackageMojo {
@@ -107,6 +109,12 @@ public class GenerateMetadataMojo extends AbstractPackageMojo {
      */
     @Component
     private BuildContext buildContext;
+
+    /**
+     * For correct source of standard embedded path base name.
+     */
+    @Component(hint = "default")
+    private ArtifactRepositoryLayout embedArtifactLayout;
 
     /**
      * The Maven session.
@@ -852,7 +860,7 @@ public class GenerateMetadataMojo extends AbstractPackageMojo {
 
                 // todo: add support for patterns
                 if (destFileName == null) {
-                    destFileName = source.getName();
+                    destFileName = Text.getName(embedArtifactLayout.pathOf(artifact));
                 }
                 final String targetPathName = targetPath + destFileName;
                 final String targetNodePathName = targetPathName.substring(JCR_ROOT.length() - 1);

--- a/src/test/java/org/apache/jackrabbit/filevault/maven/packaging/it/GenerateMetadataMultiModuleIT.java
+++ b/src/test/java/org/apache/jackrabbit/filevault/maven/packaging/it/GenerateMetadataMultiModuleIT.java
@@ -21,15 +21,31 @@ import org.junit.Test;
 public class GenerateMetadataMultiModuleIT {
 
     /**
-     * Tests that the generate-manifest goal succeeds when run on
-     * inter-module dependencies in a multi-module setup.
+     * Tests that the generate-manifest goal generates the expected filter.xml when run on
+     * inter-module dependencies in a multi-module setup for clean + test goals.
      */
     @Test
-    public void multi_module_build_succeeds() throws Exception {
+    public void multi_module_build_clean_test() throws Exception {
         new ProjectBuilder()
                 .setTestProjectDir("/generate-metadata-multimodule")
                 .setTestGoals("clean", "test")
                 .setVerifyPackageContents(false)
-                .build();
+                .build()
+                .verifyExpectedFilterInWorkDirectory("container/target/vault-work");
+    }
+
+    /**
+     * Tests that the generate-manifest goal generates the expected filter.xml when run on
+     * inter-module dependencies in a multi-module setup for clean + test goals.
+     */
+    @Test
+    public void multi_module_build_clean_package() throws Exception {
+        new ProjectBuilder()
+                .setTestProjectDir("/generate-metadata-multimodule")
+                .setTestPackageFile("container/" + ProjectBuilder.TEST_PACKAGE_DEFAULT_NAME)
+                .setTestGoals("clean", "package")
+                .setVerifyPackageContents(false)
+                .build()
+                .verifyExpectedFilter();
     }
 }

--- a/src/test/java/org/apache/jackrabbit/filevault/maven/packaging/it/GenerateMetadataMultiModuleIT.java
+++ b/src/test/java/org/apache/jackrabbit/filevault/maven/packaging/it/GenerateMetadataMultiModuleIT.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.jackrabbit.filevault.maven.packaging.it;
+
+import org.junit.Test;
+
+public class GenerateMetadataMultiModuleIT {
+
+    /**
+     * Tests that the generate-manifest goal succeeds when run on
+     * inter-module dependencies in a multi-module setup.
+     */
+    @Test
+    public void multi_module_build_succeeds() throws Exception {
+        new ProjectBuilder()
+                .setTestProjectDir("/generate-metadata-multimodule")
+                .setTestGoals("clean", "test")
+                .setVerifyPackageContents(false)
+                .build();
+    }
+}

--- a/src/test/java/org/apache/jackrabbit/filevault/maven/packaging/it/ProjectBuilder.java
+++ b/src/test/java/org/apache/jackrabbit/filevault/maven/packaging/it/ProjectBuilder.java
@@ -169,6 +169,11 @@ public class ProjectBuilder {
         return this;
     }
 
+    public ProjectBuilder setTestPackageFile(String testPackageFileName) {
+        this.setTestPackageFile(new File(testProjectDir, testPackageFileName));
+        return this;
+    }
+
     public File getTestPackageFile() {
         return testPackageFile;
     }
@@ -331,6 +336,20 @@ public class ProjectBuilder {
             String expected = FileUtils.fileRead(expectedFilterFile);
             assertEquals("filter.xml is correct", normalizeWhitespace(expected), normalizeWhitespace(result));
         }
+        return this;
+    }
+
+    public ProjectBuilder verifyExpectedFilterInWorkDirectory(final String workDirectory) throws IOException {
+        if (buildExpectedToFail) {
+            return this;
+        }
+        File workDirFile = new File(testProjectDir, workDirectory);
+        assertTrue("workDirectory should exist: " + workDirFile.toString(), workDirFile.isDirectory());
+        File filterFile = new File(workDirFile, "META-INF/vault/filter.xml");
+        assertTrue("filterFile should exist: " + filterFile.toString(), filterFile.isFile());
+        String result = FileUtils.fileRead(filterFile);
+        String expected = FileUtils.fileRead(expectedFilterFile);
+        assertEquals("filter.xml is incorrect", normalizeWhitespace(expected), normalizeWhitespace(result));
         return this;
     }
 

--- a/src/test/resources/test-projects/generate-metadata-multimodule/bundle1/pom.xml
+++ b/src/test/resources/test-projects/generate-metadata-multimodule/bundle1/pom.xml
@@ -1,0 +1,40 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.jackrabbit.filevault</groupId>
+        <artifactId>package-plugin-test-pkg-parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>package-plugin-test-pkg-bundle1</artifactId>
+    <packaging>bundle</packaging>
+
+    <name>Packaging test bundle artifact</name>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>3.5.0</version>
+                <extensions>true</extensions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/test/resources/test-projects/generate-metadata-multimodule/bundle1/src/main/java/bundle1/SomeClass.java
+++ b/src/test/resources/test-projects/generate-metadata-multimodule/bundle1/src/main/java/bundle1/SomeClass.java
@@ -1,0 +1,19 @@
+package bundle1;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+public class SomeClass {}

--- a/src/test/resources/test-projects/generate-metadata-multimodule/bundle2/pom.xml
+++ b/src/test/resources/test-projects/generate-metadata-multimodule/bundle2/pom.xml
@@ -1,0 +1,40 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.jackrabbit.filevault</groupId>
+        <artifactId>package-plugin-test-pkg-parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>package-plugin-test-pkg-bundle2</artifactId>
+    <packaging>bundle</packaging>
+
+    <name>Packaging test bundle artifact</name>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>3.5.0</version>
+                <extensions>true</extensions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/test/resources/test-projects/generate-metadata-multimodule/bundle2/src/main/java/bundle2/SomeClass.java
+++ b/src/test/resources/test-projects/generate-metadata-multimodule/bundle2/src/main/java/bundle2/SomeClass.java
@@ -1,0 +1,19 @@
+package bundle2;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+public class SomeClass {}

--- a/src/test/resources/test-projects/generate-metadata-multimodule/bundle3/pom.xml
+++ b/src/test/resources/test-projects/generate-metadata-multimodule/bundle3/pom.xml
@@ -22,13 +22,12 @@
         <artifactId>package-plugin-test-pkg-parent</artifactId>
         <version>1.0.0-SNAPSHOT</version>
     </parent>
-    <artifactId>package-plugin-test-pkg-bundle1</artifactId>
+    <artifactId>package-plugin-test-pkg-bundle3</artifactId>
     <packaging>bundle</packaging>
 
     <name>Packaging test bundle artifact</name>
 
     <build>
-        <finalName>bundle1</finalName>
         <plugins>
             <plugin>
                 <groupId>org.apache.felix</groupId>

--- a/src/test/resources/test-projects/generate-metadata-multimodule/bundle3/src/main/java/bundle3/SomeClass.java
+++ b/src/test/resources/test-projects/generate-metadata-multimodule/bundle3/src/main/java/bundle3/SomeClass.java
@@ -1,0 +1,19 @@
+package bundle3;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+public class SomeClass {}

--- a/src/test/resources/test-projects/generate-metadata-multimodule/container/pom.xml
+++ b/src/test/resources/test-projects/generate-metadata-multimodule/container/pom.xml
@@ -1,0 +1,90 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.jackrabbit.filevault</groupId>
+        <artifactId>package-plugin-test-pkg-parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>package-plugin-test-pkg-container</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>content-package</packaging>
+    <name>Packaging test</name>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.jackrabbit</groupId>
+                <artifactId>filevault-package-maven-plugin</artifactId>
+                <version>${plugin.version}</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <embeddeds>
+                        <embedded>
+                            <groupId>${project.groupId}</groupId>
+                            <artifactId>package-plugin-test-pkg-bundle1</artifactId>
+                            <filter>true</filter>
+                        </embedded>
+                        <embedded>
+                            <groupId>${project.groupId}</groupId>
+                            <artifactId>package-plugin-test-pkg-bundle2</artifactId>
+                            <filter>true</filter>
+                        </embedded>
+                    </embeddeds>
+                    <subPackages>
+                        <subPackage>
+                            <groupId>${project.groupId}</groupId>
+                            <artifactId>package-plugin-test-pkg-sub1</artifactId>
+                            <filter>true</filter>
+                        </subPackage>
+                        <subPackage>
+                            <groupId>${project.groupId}</groupId>
+                            <artifactId>package-plugin-test-pkg-sub2</artifactId>
+                            <filter>true</filter>
+                        </subPackage>
+                    </subPackages>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>package-plugin-test-pkg-bundle1</artifactId>
+            <version>1.0.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>package-plugin-test-pkg-bundle2</artifactId>
+            <version>1.0.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>package-plugin-test-pkg-sub1</artifactId>
+            <version>1.0.0-SNAPSHOT</version>
+            <type>zip</type>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>package-plugin-test-pkg-sub2</artifactId>
+            <version>1.0.0-SNAPSHOT</version>
+            <type>zip</type>
+        </dependency>
+    </dependencies>
+</project>

--- a/src/test/resources/test-projects/generate-metadata-multimodule/container/pom.xml
+++ b/src/test/resources/test-projects/generate-metadata-multimodule/container/pom.xml
@@ -21,7 +21,7 @@
         <artifactId>package-plugin-test-pkg-parent</artifactId>
         <version>1.0.0-SNAPSHOT</version>
     </parent>
-    <artifactId>package-plugin-test-pkg-container</artifactId>
+    <artifactId>package-plugin-test-pkg</artifactId>
     <version>1.0.0-SNAPSHOT</version>
     <packaging>content-package</packaging>
     <name>Packaging test</name>
@@ -44,6 +44,12 @@
                             <groupId>${project.groupId}</groupId>
                             <artifactId>package-plugin-test-pkg-bundle2</artifactId>
                             <filter>true</filter>
+                        </embedded>
+                        <embedded>
+                            <groupId>${project.groupId}</groupId>
+                            <artifactId>package-plugin-test-pkg-bundle3</artifactId>
+                            <filter>true</filter>
+                            <destFileName>bundle3-core.jar</destFileName>
                         </embedded>
                     </embeddeds>
                     <subPackages>
@@ -72,6 +78,11 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>package-plugin-test-pkg-bundle2</artifactId>
+            <version>1.0.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>package-plugin-test-pkg-bundle3</artifactId>
             <version>1.0.0-SNAPSHOT</version>
         </dependency>
         <dependency>

--- a/src/test/resources/test-projects/generate-metadata-multimodule/expected-filter.xml
+++ b/src/test/resources/test-projects/generate-metadata-multimodule/expected-filter.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<workspaceFilter version="1.0">
+    <filter root="/apps/bundles/install/bundle1.jar"/>
+    <filter root="/apps/bundles/install/package-plugin-test-pkg-bundle2-1.0.0-SNAPSHOT.jar"/>
+    <filter root="/apps/bundles/install/bundle3-core.jar"/>
+    <filter root="/etc/packages/test/package-plugin-test-pkg-sub1-1.0.0-SNAPSHOT.zip"/>
+    <filter root="/etc/packages/test/package-plugin-test-pkg-sub2-1.0.0-SNAPSHOT.zip"/>
+</workspaceFilter>

--- a/src/test/resources/test-projects/generate-metadata-multimodule/pom.xml
+++ b/src/test/resources/test-projects/generate-metadata-multimodule/pom.xml
@@ -1,0 +1,35 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <!-- ====================================================================== -->
+    <!-- P R O J E C T  D E S C R I P T I O N                                   -->
+    <!-- ====================================================================== -->
+    <groupId>org.apache.jackrabbit.filevault</groupId>
+    <artifactId>package-plugin-test-pkg-parent</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+    <name>Parent</name>
+    <modules>
+        <module>bundle1</module>
+        <module>bundle2</module>
+        <module>sub1</module>
+        <module>sub2</module>
+        <module>container</module>
+    </modules>
+</project>

--- a/src/test/resources/test-projects/generate-metadata-multimodule/pom.xml
+++ b/src/test/resources/test-projects/generate-metadata-multimodule/pom.xml
@@ -28,6 +28,7 @@
     <modules>
         <module>bundle1</module>
         <module>bundle2</module>
+        <module>bundle3</module>
         <module>sub1</module>
         <module>sub2</module>
         <module>container</module>

--- a/src/test/resources/test-projects/generate-metadata-multimodule/sub1/pom.xml
+++ b/src/test/resources/test-projects/generate-metadata-multimodule/sub1/pom.xml
@@ -1,0 +1,52 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.jackrabbit.filevault</groupId>
+        <artifactId>package-plugin-test-pkg-parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>package-plugin-test-pkg-sub1</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>content-package</packaging>
+    <name>Packaging test</name>
+
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/content/META-INF</directory>
+                <targetPath>${project.build.directory}/vault-work/META-INF</targetPath>
+            </resource>
+            <resource>
+                <directory>src/main/content/jcr_root</directory>
+                <targetPath>.</targetPath>
+            </resource>
+        </resources>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.jackrabbit</groupId>
+                <artifactId>filevault-package-maven-plugin</artifactId>
+                <version>${plugin.version}</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <group>test</group>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/test/resources/test-projects/generate-metadata-multimodule/sub1/src/main/content/META-INF/vault/filter.xml
+++ b/src/test/resources/test-projects/generate-metadata-multimodule/sub1/src/main/content/META-INF/vault/filter.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+<workspaceFilter version="1.0">
+    <filter root="/sub1"/>
+</workspaceFilter>

--- a/src/test/resources/test-projects/generate-metadata-multimodule/sub1/src/main/content/jcr_root/sub1/.content.xml
+++ b/src/test/resources/test-projects/generate-metadata-multimodule/sub1/src/main/content/jcr_root/sub1/.content.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="sling:Folder"/>

--- a/src/test/resources/test-projects/generate-metadata-multimodule/sub2/pom.xml
+++ b/src/test/resources/test-projects/generate-metadata-multimodule/sub2/pom.xml
@@ -1,0 +1,52 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.jackrabbit.filevault</groupId>
+        <artifactId>package-plugin-test-pkg-parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>package-plugin-test-pkg-sub2</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>content-package</packaging>
+    <name>Packaging test</name>
+
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/content/META-INF</directory>
+                <targetPath>${project.build.directory}/vault-work/META-INF</targetPath>
+            </resource>
+            <resource>
+                <directory>src/main/content/jcr_root</directory>
+                <targetPath>.</targetPath>
+            </resource>
+        </resources>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.jackrabbit</groupId>
+                <artifactId>filevault-package-maven-plugin</artifactId>
+                <version>${plugin.version}</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <group>test</group>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/test/resources/test-projects/generate-metadata-multimodule/sub2/src/main/content/META-INF/vault/filter.xml
+++ b/src/test/resources/test-projects/generate-metadata-multimodule/sub2/src/main/content/META-INF/vault/filter.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+<workspaceFilter version="1.0">
+    <filter root="/sub2"/>
+</workspaceFilter>

--- a/src/test/resources/test-projects/generate-metadata-multimodule/sub2/src/main/content/jcr_root/sub2/.content.xml
+++ b/src/test/resources/test-projects/generate-metadata-multimodule/sub2/src/main/content/jcr_root/sub2/.content.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="sling:Folder"/>


### PR DESCRIPTION
Also, change `defaultPhase` attribute of `@Mojo` annotation to agree with lifecycle-mapping defined in `META-INF/plexus/components.xml`.