### PR TITLE
JCRVLT-320 upgrade to maven-archiver 3.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -327,12 +327,12 @@
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-archiver</artifactId>
-            <version>3.2.0</version>
+            <version>3.4.0</version>
         </dependency>
         <dependency>
             <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-archiver</artifactId>
-            <version>3.5</version>
+            <version>4.1.0</version>
         </dependency>
         <dependency>
             <groupId>org.codehaus.plexus</groupId>

--- a/src/test/java/org/apache/jackrabbit/filevault/maven/packaging/it/ProjectBuilder.java
+++ b/src/test/java/org/apache/jackrabbit/filevault/maven/packaging/it/ProjectBuilder.java
@@ -69,7 +69,7 @@ public class ProjectBuilder {
      */
     private static final Logger log = LoggerFactory.getLogger(ProjectBuilder.class);
 
-    private static final Set<String> IGNORED_MANIFEST_ENTRIES = new HashSet<>(Arrays.asList("Build-Jdk", "Built-By", "Created-By"));
+    private static final Set<String> IGNORED_MANIFEST_ENTRIES = new HashSet<>(Arrays.asList("Build-Jdk-Spec", "Created-By"));
 
     static final String TEST_PROJECTS_ROOT = "target/test-classes/test-projects";
 

--- a/src/test/resources/test-projects/default-test-projects/generic-unusal-jcrroot/expected-manifest.txt
+++ b/src/test/resources/test-projects/default-test-projects/generic-unusal-jcrroot/expected-manifest.txt
@@ -3,6 +3,5 @@ Content-Package-Id:org.apache.jackrabbit.filevault:package-plugin-test-pkg:1.0.0
 Content-Package-Roots:/apps/some-thirdparty-libs,/apps/wcm/core/content,/etc/cloudservices/ooyala,/etc/designs/some-thirdparty-libs,/etc/packages/apache/consulting,/rep:policy
 Content-Package-Type:mixed
 Implementation-Title:Packaging test
-Implementation-Vendor-Id:org.apache.jackrabbit.filevault
 Implementation-Version:1.0.0-SNAPSHOT
 Manifest-Version:1.0

--- a/src/test/resources/test-projects/default-test-projects/generic-with-builtcd/expected-manifest.txt
+++ b/src/test/resources/test-projects/default-test-projects/generic-with-builtcd/expected-manifest.txt
@@ -3,6 +3,5 @@ Content-Package-Id:org.apache.jackrabbit.filevault:package-plugin-test-pkg:1.0.0
 Content-Package-Roots:/apps/some-thirdparty-libs,/apps/wcm/core/content,/etc/cloudservices/ooyala,/etc/designs/some-thirdparty-libs,/etc/packages/apache/consulting,/rep:policy
 Content-Package-Type:mixed
 Implementation-Title:Packaging test
-Implementation-Vendor-Id:org.apache.jackrabbit.filevault
 Implementation-Version:1.0.0-SNAPSHOT
 Manifest-Version:1.0

--- a/src/test/resources/test-projects/default-test-projects/generic-with-metainf/expected-manifest.txt
+++ b/src/test/resources/test-projects/default-test-projects/generic-with-metainf/expected-manifest.txt
@@ -3,6 +3,5 @@ Content-Package-Id:org.apache.jackrabbit.filevault:package-plugin-test-pkg:1.0.0
 Content-Package-Roots:/apps/wcm/core/content,/rep:policy
 Content-Package-Type:mixed
 Implementation-Title:Packaging test
-Implementation-Vendor-Id:org.apache.jackrabbit.filevault
 Implementation-Version:1.0.0-SNAPSHOT
 Manifest-Version:1.0

--- a/src/test/resources/test-projects/default-test-projects/generic/expected-manifest.txt
+++ b/src/test/resources/test-projects/default-test-projects/generic/expected-manifest.txt
@@ -3,6 +3,5 @@ Content-Package-Id:org.apache.jackrabbit.filevault:package-plugin-test-pkg:1.0.0
 Content-Package-Roots:/apps/some-thirdparty-libs,/apps/wcm/core/content,/etc/cloudservices/ooyala,/etc/designs/some-thirdparty-libs,/etc/packages/apache/consulting,/rep:policy
 Content-Package-Type:mixed
 Implementation-Title:Packaging test
-Implementation-Vendor-Id:org.apache.jackrabbit.filevault
 Implementation-Version:1.0.0-SNAPSHOT
 Manifest-Version:1.0

--- a/src/test/resources/test-projects/default-test-projects/htl-validation/expected-manifest.txt
+++ b/src/test/resources/test-projects/default-test-projects/htl-validation/expected-manifest.txt
@@ -3,7 +3,6 @@ Content-Package-Id:org.apache.jackrabbit.filevault:package-plugin-test-pkg:1.0.0
 Content-Package-Roots:/apps/htl/test
 Content-Package-Type:application
 Implementation-Title:Packaging test
-Implementation-Vendor-Id:org.apache.jackrabbit.filevault
 Implementation-Version:1.0.0-SNAPSHOT
 Import-Package:javax.jcr;version="[2.0.0,3.0.0)"
 Import-Package:org.apache.sling.scripting.sightly;version="[2.0.0,3.0.0)"

--- a/src/test/resources/test-projects/default-test-projects/resource/expected-manifest.txt
+++ b/src/test/resources/test-projects/default-test-projects/resource/expected-manifest.txt
@@ -3,6 +3,5 @@ Content-Package-Id:org.apache.jackrabbit.filevault:package-plugin-test-pkg:1.0.0
 Content-Package-Roots:/apps/some-thirdparty-libs,/apps/wcm/core/content,/etc/cloudservices/ooyala,/etc/designs/some-thirdparty-libs,/etc/packages/apache/consulting,/rep:policy
 Content-Package-Type:mixed
 Implementation-Title:Packaging test
-Implementation-Vendor-Id:org.apache.jackrabbit.filevault
 Implementation-Version:1.0.0-SNAPSHOT
 Manifest-Version:1.0

--- a/src/test/resources/test-projects/manifest-generation/simple/expected-manifest.txt
+++ b/src/test/resources/test-projects/manifest-generation/simple/expected-manifest.txt
@@ -4,7 +4,6 @@ Content-Package-Id:my/test/group:package-plugin-test-pkg:1.0.0-SNAPSHOT
 Content-Package-Roots:/apps/test,/apps/test2
 Content-Package-Type:application
 Implementation-Title:Example Default Project
-Implementation-Vendor-Id:org.apache.jackrabbit.filevault
 Implementation-Version:1.0.0-SNAPSHOT
 Import-Package:com.apache.components;version="[5.5.0,6)"
 Import-Package:javax.jcr;version="[2.0.0,3)"

--- a/src/test/resources/test-projects/manifest-generation/with-bundles/expected-manifest.txt
+++ b/src/test/resources/test-projects/manifest-generation/with-bundles/expected-manifest.txt
@@ -3,7 +3,6 @@ Content-Package-Id:my/test/group:package-plugin-test-pkg:1.0.0-SNAPSHOT
 Content-Package-Roots:/apps/test
 Content-Package-Type:application
 Implementation-Title:Example Default Project
-Implementation-Vendor-Id:org.apache.jackrabbit.filevault
 Implementation-Version:1.0.0-SNAPSHOT
 Import-Package:javax.jcr.lock;version="[1.0.0,3.0.0)"
 Import-Package:javax.jcr.nodetype;version="[1.0.0,3.0.0)"

--- a/src/test/resources/test-projects/manifest-generation/with-code/expected-manifest.txt
+++ b/src/test/resources/test-projects/manifest-generation/with-code/expected-manifest.txt
@@ -3,7 +3,6 @@ Content-Package-Id:my/test/group:package-plugin-test-pkg:1.0.0-SNAPSHOT
 Content-Package-Roots:/libs/apache
 Content-Package-Type:application
 Implementation-Title:Example Default Project
-Implementation-Vendor-Id:org.apache.jackrabbit.filevault
 Implementation-Version:1.0.0-SNAPSHOT
 Import-Package:javax.servlet;
 Import-Package:org.apache.jackrabbit.api.query;

--- a/src/test/resources/test-projects/manifest-generation/with-unused-dependencies/expected-manifest.txt
+++ b/src/test/resources/test-projects/manifest-generation/with-unused-dependencies/expected-manifest.txt
@@ -3,6 +3,5 @@ Content-Package-Id:my/test/group:package-plugin-test-pkg:1.0.0-SNAPSHOT
 Content-Package-Roots:/apps/test
 Content-Package-Type:application
 Implementation-Title:Example Default Project
-Implementation-Vendor-Id:org.apache.jackrabbit.filevault
 Implementation-Version:1.0.0-SNAPSHOT
 Manifest-Version:1.0

--- a/src/test/resources/test-projects/manifest-generation/with-unused-parent-dependencies/expected-manifest.txt
+++ b/src/test/resources/test-projects/manifest-generation/with-unused-parent-dependencies/expected-manifest.txt
@@ -3,7 +3,6 @@ Content-Package-Id:my/test/group:package-plugin-test-pkg:1.0.0-SNAPSHOT
 Content-Package-Roots:/libs/apache
 Content-Package-Type:application
 Implementation-Title:Example Default Project
-Implementation-Vendor-Id:org.apache.jackrabbit.filevault
 Implementation-Version:1.0.0-SNAPSHOT
 Import-Package:javax.servlet;
 Import-Package:org.apache.jackrabbit.api.query;


### PR DESCRIPTION
The attributes "Built-By"
(https://issues.apache.org/jira/browse/MSHARED-661) and
"Implementation-Vendor-Id"
(https://issues.apache.org/jira/browse/MSHARED-777) have been removed.
The attribute "Build-Jdk" has been renamed to "Build-Jdk-Spec"
(https://issues.apache.org/jira/browse/MSHARED-797)