### PR TITLE
JCRVLT-681 fix default excludes in "validate-files"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -288,6 +288,13 @@
                             </resources>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>default-testResources</id>
+                        <configuration>
+                            <!-- copy .gitignore as well -->
+                            <addDefaultExcludes>false</addDefaultExcludes>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
             <plugin>

--- a/src/main/java/org/apache/jackrabbit/filevault/maven/packaging/mojo/AbstractSourceAndMetadataPackageMojo.java
+++ b/src/main/java/org/apache/jackrabbit/filevault/maven/packaging/mojo/AbstractSourceAndMetadataPackageMojo.java
@@ -47,7 +47,6 @@ public abstract class AbstractSourceAndMetadataPackageMojo extends AbstractMetad
             + "${project.basedir}/src/content/jcr_root," + "${project.build.outputDirectory}")
     private File[] jcrRootSourceDirectory;
 
-    
     /**
      * The file name patterns to exclude (in addition to the default ones mentioned at {@link AbstractSourceAndMetadataPackageMojo#addDefaultExcludes}. The format of each pattern is described in {@link org.codehaus.plexus.util.DirectoryScanner}.
      * The comparison is against the path relative to the according filter root.
@@ -57,7 +56,7 @@ public abstract class AbstractSourceAndMetadataPackageMojo extends AbstractMetad
      * Each value is either a regex pattern if enclosed within {@code %regex[} and {@code ]}, otherwise an 
      * <a href="https://ant.apache.org/manual/dirtasks.html#patterns">Ant pattern</a>.
      */
-    @Parameter(property = "vault.excludes", defaultValue = "**/.vlt,**/.vltignore,**/.gitignore", required = true)
+    @Parameter(property = "vault.excludes", defaultValue = "**/.vlt,**/.vltignore,**/.gitignore,**/.gitattributes", required = true)
     protected Set<String> excludes;
 
     /**

--- a/src/main/java/org/apache/jackrabbit/filevault/maven/packaging/mojo/ValidateFilesMojo.java
+++ b/src/main/java/org/apache/jackrabbit/filevault/maven/packaging/mojo/ValidateFilesMojo.java
@@ -149,8 +149,35 @@ public class ValidateFilesMojo extends AbstractValidateMojo {
      * Each value is either a regex pattern if enclosed within {@code %regex[} and {@code ]}, otherwise an 
      * <a href="https://ant.apache.org/manual/dirtasks.html#patterns">Ant pattern</a>.
      */
-    @Parameter(property = "vault.excludes", defaultValue = "**/.vlt,**/.vltignore", required = true)
+    @Parameter(property = "vault.excludes", defaultValue = "**/.vlt,**/.vltignore,**/.gitignore,**/.gitattributes", required = true)
     protected String[] excludes;
+
+    /**
+     * By default certain metadata files are excluded which means they will not be copied into the package. 
+     * If you need them for a particular reason you can do that by setting this parameter to {@code false}. This means
+     * all files matching the following <a href="https://ant.apache.org/manual/dirtasks.html#patterns">Ant patterns</a> won't be copied by default.
+     * <ul>
+     * <li>Misc: &#42;&#42;/&#42;~, &#42;&#42;/#&#42;#, &#42;&#42;/.#&#42;, &#42;&#42;/%&#42;%, &#42;&#42;/._&#42;</li>
+     * <li>CVS: &#42;&#42;/CVS, &#42;&#42;/CVS/&#42;&#42;, &#42;&#42;/.cvsignore</li>
+     * <li>SVN: &#42;&#42;/.svn, &#42;&#42;/.svn/&#42;&#42;</li>
+     * <li>GNU: &#42;&#42;/.arch-ids, &#42;&#42;/.arch-ids/&#42;&#42;</li>
+     * <li>Bazaar: &#42;&#42;/.bzr, &#42;&#42;/.bzr/&#42;&#42;</li>
+     * <li>SurroundSCM: &#42;&#42;/.MySCMServerInfo</li>
+     * <li>Mac: &#42;&#42;/.DS_Store</li>
+     * <li>Serena Dimension: &#42;&#42;/.metadata, &#42;&#42;/.metadata/&#42;&#42;</li>
+     * <li>Mercurial: &#42;&#42;/.hg, &#42;&#42;/.hg/&#42;&#42;</li>
+     * <li>GIT: &#42;&#42;/.git, &#42;&#42;/.git/&#42;&#42;</li>
+     * <li>Bitkeeper: &#42;&#42;/BitKeeper, &#42;&#42;/BitKeeper/&#42;&#42;, &#42;&#42;/ChangeSet,
+     * &#42;&#42;/ChangeSet/&#42;&#42;</li>
+     * <li>Darcs: &#42;&#42;/_darcs, &#42;&#42;/_darcs/&#42;&#42;, &#42;&#42;/.darcsrepo,
+     * &#42;&#42;/.darcsrepo/&#42;&#42;&#42;&#42;/-darcs-backup&#42;, &#42;&#42;/.darcs-temp-mail
+     * </ul>
+     *
+     * @see org.codehaus.plexus.util.AbstractScanner#DEFAULTEXCLUDES
+     * @since 1.3.4
+     */
+    @Parameter(defaultValue = "true")
+    protected boolean addDefaultExcludes;
     //-----
     // End: Copied from AbstractSourceAndMetadataPackageMojo
     // -----
@@ -229,7 +256,9 @@ public class ValidateFilesMojo extends AbstractValidateMojo {
         Scanner scanner = buildContext.newScanner(baseDir.toFile());
         // make sure filtering does work equally as within the package goal
         scanner.setExcludes(excludes);
-        scanner.addDefaultExcludes();
+        if (addDefaultExcludes) {
+            scanner.addDefaultExcludes();
+        }
         scanner.scan();
         getLog().info("Scanning baseDir " + getProjectRelativeFilePath(baseDir) + "...");
         SortedSet<Path> sortedFileAndFolderNames = sortAndEnrichFilesAndDirectories(baseDir, scanner.getIncludedFiles(), scanner.getIncludedDirectories());

--- a/src/test/java/org/apache/jackrabbit/filevault/maven/packaging/it/ValidateFilesIT.java
+++ b/src/test/java/org/apache/jackrabbit/filevault/maven/packaging/it/ValidateFilesIT.java
@@ -35,4 +35,12 @@ class ValidateFilesIT {
             .build()
             .verifyExpectedLogLines(Paths.get("META-INF","vault","filter.xml").toString());
     }
+
+    @Test
+    void testValidProjectWithZip(ProjectBuilder projectBuilder) throws Exception {
+        projectBuilder
+            .setTestProjectDir("/validator-projects/valid-project-with-zip")
+            .setTestGoals("clean", "package") // make sure the validate-files mojo is not skipped
+            .build();
+    }
 }

--- a/src/test/resources/test-projects/validator-projects/valid-project-with-zip/jcr_root/.gitignore
+++ b/src/test/resources/test-projects/validator-projects/valid-project-with-zip/jcr_root/.gitignore
@@ -1,0 +1,1 @@
+sometest


### PR DESCRIPTION
Extend test to check that .gitignore files and .gitattributes files are ignored for validation (both in validate-package and validate-files)