### PR TITLE
JCRVLT-780 Get rid of Component annotation for injection of components

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,7 @@
         <filevault.version>${project.parent.version}</filevault.version> <!-- must be equal to parent version -->
         <maven.compiler.release>8</maven.compiler.release>
         <project.build.outputTimestamp>2023-11-13T16:28:26Z</project.build.outputTimestamp>
+        <version.maven-plugin-tools>3.15.0</version.maven-plugin-tools>
     </properties>
 
     <prerequisites>

--- a/src/main/java/org/apache/jackrabbit/filevault/maven/packaging/mojo/AbstractValidateMojo.java
+++ b/src/main/java/org/apache/jackrabbit/filevault/maven/packaging/mojo/AbstractValidateMojo.java
@@ -32,7 +32,7 @@ import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
 
-import javax.enterprise.inject.spi.Bean;
+import javax.inject.Inject;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.jackrabbit.filevault.maven.packaging.MavenBasedPackageDependency;
@@ -53,7 +53,6 @@ import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecution;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
-import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 import org.eclipse.aether.RepositorySystem;
@@ -205,9 +204,6 @@ public abstract class AbstractValidateMojo extends AbstractMojo {
     @Parameter(property = "vault.validation.csvReportFile")
     protected File csvReportFile;
 
-    @Component
-    protected RepositorySystem repositorySystem;
-
     /**
      * The current repository/network configuration of Maven.
      */
@@ -220,21 +216,24 @@ public abstract class AbstractValidateMojo extends AbstractMojo {
     @Parameter(defaultValue = "${project.remoteProjectRepositories}", readonly = true)
     private List<RemoteRepository> projectRepos;
 
-    @Component
-    protected BuildContext buildContext;
-
     protected final ValidationExecutorFactory validationExecutorFactory;
 
     protected DependencyResolver resolver;
 
+    protected final RepositorySystem repositorySystem;
+    protected final BuildContext buildContext;
+    
     /**
      * Artificial Maven artifact which indicates that it should not be considered for further lookup!
      */
     public static final Artifact IGNORE_ARTIFACT = new DefaultArtifact("ignore", "ignore", null, null);
 
-    public AbstractValidateMojo() {
+    @Inject
+    protected AbstractValidateMojo(RepositorySystem repositorySystem, BuildContext buildContext) {
         super();
         this.validationExecutorFactory = new ValidationExecutorFactory(this.getClass().getClassLoader());
+        this.repositorySystem = repositorySystem;
+        this.buildContext = buildContext;
     }
 
     protected String getProjectRelativeFilePath(Path path) {

--- a/src/main/java/org/apache/jackrabbit/filevault/maven/packaging/mojo/CheckSignatureMojo.java
+++ b/src/main/java/org/apache/jackrabbit/filevault/maven/packaging/mojo/CheckSignatureMojo.java
@@ -26,12 +26,13 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import javax.inject.Inject;
+
 import org.apache.jackrabbit.filevault.maven.packaging.Embedded;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
-import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
@@ -77,10 +78,6 @@ public class CheckSignatureMojo extends AbstractMojo {
     @Parameter(property = "vault.failOnMissingEmbed", defaultValue = "false", required = true)
     private boolean failOnMissingEmbed;
 
-
-    @Component
-    private RepositorySystem repoSystem;
-
     @Parameter( defaultValue = "${repositorySystemSession}", readonly = true, required = true )
     private RepositorySystemSession repoSession;
 
@@ -110,6 +107,13 @@ public class CheckSignatureMojo extends AbstractMojo {
      */
     @Parameter(property = "vault.checksignature.skip", defaultValue="false")
     private boolean skipCheckSignature;
+
+    private final RepositorySystem repoSystem;
+
+    @Inject
+    public CheckSignatureMojo(RepositorySystem repoSystem) {
+        this.repoSystem = repoSystem;
+    }
 
     /**
      * List of packages defined in the application.

--- a/src/main/java/org/apache/jackrabbit/filevault/maven/packaging/mojo/FormatDocviewXmlMojo.java
+++ b/src/main/java/org/apache/jackrabbit/filevault/maven/packaging/mojo/FormatDocviewXmlMojo.java
@@ -25,12 +25,13 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import javax.inject.Inject;
+
 import org.apache.jackrabbit.vault.fs.io.DocViewFormat;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugin.logging.Log;
-import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
@@ -100,8 +101,12 @@ public class FormatDocviewXmlMojo extends AbstractMojo {
     @Parameter(defaultValue = "false")
     private boolean enableForIncrementalBuild;
 
-    @Component
-    protected BuildContext buildContext;
+    private final BuildContext buildContext;
+
+    @Inject
+    public FormatDocviewXmlMojo(BuildContext buildContext) {
+        this.buildContext = buildContext;
+    }
 
     private static final String MSG_MALFORMED_FILE = "Malformed according to DocView format";
     private static final String MSG_COUNTERMEASURE = "Use \"mvn filevault-package:format-xml\" to reformat the malformed files.";

--- a/src/main/java/org/apache/jackrabbit/filevault/maven/packaging/mojo/ValidateFilesMojo.java
+++ b/src/main/java/org/apache/jackrabbit/filevault/maven/packaging/mojo/ValidateFilesMojo.java
@@ -34,6 +34,8 @@ import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
 
+import javax.inject.Inject;
+
 import org.apache.commons.lang3.StringUtils;
 import org.apache.jackrabbit.filevault.maven.packaging.impl.DirectoryValidationContext;
 import org.apache.jackrabbit.filevault.maven.packaging.impl.ValidationMessagePrinter;
@@ -57,13 +59,14 @@ import org.apache.maven.plugin.PluginNotFoundException;
 import org.apache.maven.plugin.PluginResolutionException;
 import org.apache.maven.plugin.prefix.NoPluginFoundForPrefixException;
 import org.apache.maven.plugin.version.PluginVersionResolutionException;
-import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.codehaus.plexus.util.AbstractScanner;
 import org.codehaus.plexus.util.Scanner;
+import org.eclipse.aether.RepositorySystem;
+import org.sonatype.plexus.build.incremental.BuildContext;
 
 /** 
  * Validates individual files with all registered validators. This is only active for incremental builds (i.e. inside m2e)
@@ -182,12 +185,14 @@ public class ValidateFilesMojo extends AbstractValidateMojo {
     // End: Copied from AbstractSourceAndMetadataPackageMojo
     // -----
 
-    @Component
-    protected LifecycleExecutor lifecycleExecutor;
+    protected final LifecycleExecutor lifecycleExecutor;
 
     private static final String PLUGIN_KEY = "org.apache.jackrabbit:filevault-package-maven-plugin";
 
-    public ValidateFilesMojo() {
+    @Inject
+    public ValidateFilesMojo(RepositorySystem repositorySystem, BuildContext buildContext, LifecycleExecutor lifecycleExecutor) {
+        super(repositorySystem, buildContext);
+        this.lifecycleExecutor = lifecycleExecutor;
     }
 
     @Override

--- a/src/main/java/org/apache/jackrabbit/filevault/maven/packaging/mojo/ValidatePackageMojo.java
+++ b/src/main/java/org/apache/jackrabbit/filevault/maven/packaging/mojo/ValidatePackageMojo.java
@@ -26,6 +26,8 @@ import java.util.Collection;
 import java.util.Comparator;
 import java.util.LinkedList;
 import java.util.List;
+
+import javax.inject.Inject;
 import javax.xml.parsers.ParserConfigurationException;
 
 import org.apache.jackrabbit.filevault.maven.packaging.impl.ValidationMessagePrinter;
@@ -46,7 +48,9 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.codehaus.plexus.util.StringUtils;
+import org.eclipse.aether.RepositorySystem;
 import org.jetbrains.annotations.Nullable;
+import org.sonatype.plexus.build.incremental.BuildContext;
 import org.xml.sax.SAXException;
 
 /**
@@ -102,7 +106,9 @@ public class ValidatePackageMojo extends AbstractValidateMojo {
     @Parameter(property = "vault.classifier")
     protected String classifier = "";
 
-    public ValidatePackageMojo() {
+    @Inject
+    public ValidatePackageMojo(RepositorySystem repositorySystem, BuildContext buildContext) {
+        super(repositorySystem, buildContext);
     }
 
     @Override

--- a/src/test/java/org/apache/jackrabbit/filevault/maven/packaging/mojo/AbstractValidateMojoTest.java
+++ b/src/test/java/org/apache/jackrabbit/filevault/maven/packaging/mojo/AbstractValidateMojoTest.java
@@ -105,7 +105,7 @@ class AbstractValidateMojoTest {
 
     @Test
     void testGetProjectRelativeFilePathWithoutRealProject() {
-        AbstractValidateMojo mojo = new AbstractValidateMojo() {
+        AbstractValidateMojo mojo = new AbstractValidateMojo(null, null) {
             @Override
             public void doExecute(ValidationMessagePrinter validationHelper) throws MojoExecutionException, MojoFailureException {
                 throw new UnsupportedOperationException();

--- a/src/test/java/org/apache/jackrabbit/filevault/maven/packaging/mojo/GenerateMetadataMojoTest.java
+++ b/src/test/java/org/apache/jackrabbit/filevault/maven/packaging/mojo/GenerateMetadataMojoTest.java
@@ -94,7 +94,7 @@ class GenerateMetadataMojoTest {
 
     @Test
     void testWriteManifest() throws FileNotFoundException, ManifestException, DependencyResolutionRequiredException, IOException {
-        GenerateMetadataMojo mojo = new GenerateMetadataMojo();
+        GenerateMetadataMojo mojo = new GenerateMetadataMojo(null, null, null);
         mojo.name = "mypackage";
         mojo.group = "mygroup";
         mojo.version = "1.4";
@@ -137,7 +137,7 @@ class GenerateMetadataMojoTest {
 
     @Test
     void testComputeDependencies() throws IOException {
-        GenerateMetadataMojo mojo = new GenerateMetadataMojo();
+        GenerateMetadataMojo mojo = new GenerateMetadataMojo(null, null, null);
         mojo.dependencies = new ArrayList<>();
         MavenBasedPackageDependency dependency = MavenBasedPackageDependency.fromGroupNameAndVersion("day/cq60/product", "cq-content", "[6.3.64,)");
         mojo.dependencies.add(dependency);
@@ -149,7 +149,7 @@ class GenerateMetadataMojoTest {
 
     @Test
     void testComputePackageType() {
-        GenerateMetadataMojo mojo = new GenerateMetadataMojo();
+        GenerateMetadataMojo mojo = new GenerateMetadataMojo(null, null, null);
         // no filter, embeds (should not happen in reality)
         assertEquals(PackageType.MIXED, mojo.computePackageType());
         mojo.embeddeds = new Embedded[]{ new Embedded() };
@@ -239,7 +239,7 @@ class GenerateMetadataMojoTest {
         Mockito.when(project.getGroupId()).thenReturn("mygroupid");
         Mockito.when(project.getVersion()).thenReturn("1.0.0-SNAPSHOT");
         Mockito.when(project.getDescription()).thenReturn("my description");
-        GenerateMetadataMojo mojo = new GenerateMetadataMojo();
+        GenerateMetadataMojo mojo = new GenerateMetadataMojo(null, null, null);
         mojo.project = project;
         mojo.group = "mygroup";
         mojo.name = "myname";


### PR DESCRIPTION
Use JSR-330 annotations with constructor injection instead. This prepares for Maven4 API already.