### PR TITLE
JCRVLT-777 Always derive default destFileName of an embedded file from

### DIFF
--- a/src/test/resources/test-projects/generate-metadata-multimodule/expected-filter.xml
+++ b/src/test/resources/test-projects/generate-metadata-multimodule/expected-filter.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <workspaceFilter version="1.0">
-    <filter root="/apps/bundles/install/bundle1.jar"/>
+    <filter root="/apps/bundles/install/package-plugin-test-pkg-bundle1-1.0.0-SNAPSHOT.jar"/>
     <filter root="/apps/bundles/install/package-plugin-test-pkg-bundle2-1.0.0-SNAPSHOT.jar"/>
     <filter root="/apps/bundles/install/bundle3-core.jar"/>
     <filter root="/etc/packages/test/package-plugin-test-pkg-sub1-1.0.0-SNAPSHOT.zip"/>


### PR DESCRIPTION
the Maven coordinates

Disregard any final name settings if the artifact is part of the reactor.
Throw in case destFileName is set but multiple artifacts match embedded filter.